### PR TITLE
Fix WSL2 static IP always (test full IP string, not only begin)

### DIFF
--- a/wsl-iphandler.sh
+++ b/wsl-iphandler.sh
@@ -113,7 +113,7 @@ get_ip_with_prefix() {
 ip_exists() {
 	set +o pipefail
 	local ip_addr=$1
-	if ip addr show dev $dev | grep -Po "inet \K[\d\./]+" 2>/dev/null | grep -qF "$ip_addr"
+	if ip addr show dev $dev | grep -Po "inet \K[\d\./]+" 2>/dev/null | grep -qF "$ip_addr/"
 	then
 		set -o pipefail
 		true


### PR DESCRIPTION
The script does not update the IP if starting with correct string.

Expected IP: 192.168.50.2
Current IP: 192.168.50.205

In this case, the script does not update the IP as expected.